### PR TITLE
Build the template out

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,14 @@
-#### Summary and Scope
+### Summary and Scope
+
 <!--- Pick one below and delete the rest -->
+<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->
 
-- Fixes #
-- Requires #
-- Relates to #
+- Fixes:
+- Requires:
+- Relates to:
 
-##### Issue Type
+#### Issue Type
+
 <!--- Delete un-needed bullets -->
 
 - Bugfix Pull Request
@@ -14,15 +17,28 @@
 
 <!--- words; describe what this change is and what it is for. -->
 
-#### Prerequisites
+### Prerequisites
+
+<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
+<!--- unchecked checkbox: [ ] -->
+<!--- checked checkbox: [x] -->
+<!--- invalid checkbox: [] -->
 
 - [ ] I have included documentation in my PR (or it is not required)
-- [ ] I tested this on internal system (x) (if yes, please include results or a description of the test)
+- [ ] I tested this on internal system (if yes, please include results or a description of the test)
+- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
  
-#### Idempotency
+### Idempotency
  
 <!--- describe testing done to verify code changes behave in an idempotent manner -->
  
-#### Risks and Mitigations
+### Risks and Mitigations
  
 <!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
+<!---
+    Example:
+    
+    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
+    is resolved and the overall risk of fatal failures is reduced.
+    
+    -->


### PR DESCRIPTION
This adds examples for checkboxes which have worked nicely for docs-csm
pull-requests.

This also removes the # on the fixes/requires/relates-to section since
we usually use JIRAs here and the # has no effect.

Some other minor tweaks too.
